### PR TITLE
feat: return llm responses with the markdown block

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,5 @@ jobs:
         run: npm install
       - name: Run the lint
         run: npm run lint
+      - name: Run the typechecks
+        run: npm run check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version:
+          - 18.x
+          - 20.x
+          - 22.x
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,8 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -26,5 +27,5 @@ jobs:
         run: npm install
       - name: Run the lint
         run: npm run lint
-      - name: Run the typechecks
+      - name: Run the typechecker
         run: npm run check

--- a/app.js
+++ b/app.js
@@ -100,11 +100,22 @@ const assistant = new Assistant({
   },
 
   /**
-   * Messages sent to the Assistant do not contain a subtype and must
-   * be deduced based on their shape and metadata (if provided).
-   * https://api.slack.com/events/message
+   * Messages sent from the user to the Assistant are handled in this listener.
+   *
+   * @see {@link https://docs.slack.dev/reference/events/message}
    */
   userMessage: async ({ client, logger, message, getThreadContext, say, setTitle, setStatus }) => {
+    /**
+     * Messages sent to the Assistant can have a specific message subtype.
+     *
+     * Here we check that the message has "text" and was sent to a thread to
+     * skip unexpected message subtypes.
+     *
+     * @see {@link https://docs.slack.dev/reference/events/message#subtypes}
+     */
+    if (!('text' in message) || !('thread_ts' in message) || !message.text || !message.thread_ts) {
+      return;
+    }
     const { channel, thread_ts } = message;
 
     try {

--- a/app.js
+++ b/app.js
@@ -18,7 +18,6 @@ const hfClient = new InferenceClient(process.env.HUGGINGFACE_API_KEY);
 const DEFAULT_SYSTEM_CONTENT = `You're an assistant in a Slack workspace.
 Users in the workspace will ask you to help them write something or to think better about a specific topic.
 You'll respond to those questions in a professional way.
-When you include markdown text, convert them to Slack compatible ones.
 When a prompt has Slack's special syntax like <@USER_ID> or <#CHANNEL_ID>, you must keep them as-is in your response.`;
 
 const assistant = new Assistant({
@@ -197,7 +196,15 @@ const assistant = new Assistant({
         });
 
         // Provide a response to the user
-        await say({ text: llmResponse.choices[0].message.content });
+        await say({
+          text: llmResponse.choices[0].message.content,
+          blocks: [
+            {
+              type: 'markdown',
+              text: llmResponse.choices[0].message.content,
+            },
+          ],
+        });
 
         return;
       }
@@ -230,7 +237,15 @@ const assistant = new Assistant({
       });
 
       // Provide a response to the user
-      await say({ text: llmResponse.choices[0].message.content });
+      await say({
+        text: llmResponse.choices[0].message.content,
+        blocks: [
+          {
+            type: 'markdown',
+            text: llmResponse.choices[0].message.content,
+          },
+        ],
+      });
     } catch (e) {
       logger.error(e);
 

--- a/app.js
+++ b/app.js
@@ -51,33 +51,46 @@ const assistant = new Assistant({
 
       await saveThreadContext();
 
-      const prompts = [
-        {
-          title: 'This is a suggested prompt',
-          message:
-            'When a user clicks a prompt, the resulting prompt message text can be passed ' +
-            'directly to your LLM for processing.\n\nAssistant, please create some helpful prompts ' +
-            'I can provide to my users.',
-        },
-      ];
-
-      // If the user opens the Assistant container in a channel, additional
-      // context is available.This can be used to provide conditional prompts
-      // that only make sense to appear in that context (like summarizing a channel).
-      if (context.channel_id) {
-        prompts.push({
-          title: 'Summarize channel',
-          message: 'Assistant, please summarize the activity in this channel!',
+      /**
+       * Provide the user up to 4 optional, preset prompts to choose from.
+       *
+       * The first `title` prop is an optional label above the prompts that
+       * defaults to 'Try these prompts:' if not provided.
+       *
+       * @see {@link https://api.slack.com/methods/assistant.threads.setSuggestedPrompts}
+       */
+      if (!context.channel_id) {
+        await setSuggestedPrompts({
+          title: 'Start with this suggested prompt:',
+          prompts: [
+            {
+              title: 'This is a suggested prompt',
+              message:
+                'When a user clicks a prompt, the resulting prompt message text ' +
+                'can be passed directly to your LLM for processing.\n\n' +
+                'Assistant, please create some helpful prompts I can provide to ' +
+                'my users.',
+            },
+          ],
         });
       }
 
       /**
-       * Provide the user up to 4 optional, preset prompts to choose from.
-       * The optional `title` prop serves as a label above the prompts. If
-       * not, provided, 'Try these prompts:' will be displayed.
-       * https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+       * If the user opens the Assistant container in a channel, additional
+       * context is available. This can be used to provide conditional prompts
+       * that only make sense to appear in that context.
        */
-      await setSuggestedPrompts({ prompts, title: 'Here are some suggested options:' });
+      if (context.channel_id) {
+        await setSuggestedPrompts({
+          title: 'Perform an action based on the channel',
+          prompts: [
+            {
+              title: 'Summarize channel',
+              message: 'Assistant, please summarize the activity in this channel!',
+            },
+          ],
+        });
+      }
     } catch (e) {
       logger.error(e);
     }

--- a/app.js
+++ b/app.js
@@ -35,18 +35,21 @@ const assistant = new Assistant({
   /**
    * `assistant_thread_started` is sent when a user opens the Assistant container.
    * This can happen via DM with the app or as a side-container within a channel.
-   * https://api.slack.com/events/assistant_thread_started
+   *
+   * @see {@link https://docs.slack.dev/reference/events/assistant_thread_started}
    */
   threadStarted: async ({ event, logger, say, setSuggestedPrompts, saveThreadContext }) => {
     const { context } = event.assistant_thread;
 
     try {
-      // Since context is not sent along with individual user messages, it's necessary to keep
-      // track of the context of the conversation to better assist the user. Sending an initial
-      // message to the user with context metadata facilitates this, and allows us to update it
-      // whenever the user changes context (via the `assistant_thread_context_changed` event).
-      // The `say` utility sends this metadata along automatically behind the scenes.
-      // !! Please note: this is only intended for development and demonstrative purposes.
+      /**
+       * Since context is not sent along with individual user messages, it's necessary to keep
+       * track of the context of the conversation to better assist the user. Sending an initial
+       * message to the user with context metadata facilitates this, and allows us to update it
+       * whenever the user changes context (via the `assistant_thread_context_changed` event).
+       * The `say` utility sends this metadata along automatically behind the scenes.
+       * !! Please note: this is only intended for development and demonstrative purposes.
+       */
       await say('Hi, how can I help?');
 
       await saveThreadContext();
@@ -57,7 +60,7 @@ const assistant = new Assistant({
        * The first `title` prop is an optional label above the prompts that
        * defaults to 'Try these prompts:' if not provided.
        *
-       * @see {@link https://api.slack.com/methods/assistant.threads.setSuggestedPrompts}
+       * @see {@link https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts}
        */
       if (!context.channel_id) {
         await setSuggestedPrompts({
@@ -101,7 +104,8 @@ const assistant = new Assistant({
    * while the Assistant container is open. If `threadContextChanged` is not
    * provided, context will be saved using the AssistantContextStore's `save`
    * method (either the DefaultAssistantContextStore or custom, if provided).
-   * https://api.slack.com/events/assistant_thread_context_changed
+   *
+   * @see {@link https://docs.slack.dev/reference/events/assistant_thread_context_changed}
    */
   threadContextChanged: async ({ logger, saveThreadContext }) => {
     // const { channel_id, thread_ts, context: assistantContext } = event.assistant_thread;
@@ -135,13 +139,15 @@ const assistant = new Assistant({
       /**
        * Set the title of the Assistant thread to capture the initial topic/question
        * as a way to facilitate future reference by the user.
-       * https://api.slack.com/methods/assistant.threads.setTitle
+       *
+       * @see {@link https://docs.slack.dev/reference/methods/assistant.threads.setTitle}
        */
       await setTitle(message.text);
 
       /**
        * Set the status of the Assistant to give the appearance of active processing.
-       * https://api.slack.com/methods/assistant.threads.setStatus
+       *
+       * @see {@link https://docs.slack.dev/reference/methods/assistant.threads.setStatus}
        */
       await setStatus('is typing..');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "dotenv": "~16.5.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "1.9.4"
+        "@biomejs/biome": "1.9.4",
+        "@types/node": "^24.0.13",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -394,12 +396,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
+      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1582,10 +1584,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A template for building Slack app Assistants",
   "main": "app.js",
   "scripts": {
+    "check": "npx tsc --checkJs --noEmit --esModuleInterop app.js",
     "start": "node app.js",
     "lint": "npx @biomejs/biome check *.js",
     "lint:fix": "npx @biomejs/biome check --write *.js"
@@ -28,6 +29,8 @@
     "dotenv": "~16.5.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.4"
+    "@biomejs/biome": "1.9.4",
+    "@types/node": "^24.0.13",
+    "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
### Type of change

- [x] New feature

### Summary

This PR returns LLM responses with the [`markdown`](https://api.slack.com/reference/block-kit/blocks#markdown) block.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
