### PR TITLE
feat: shorten app display name from assistant to agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# App Agent & Assistant Template (Bolt for JavaScript)
+# AI App Template (Bolt for JavaScript)
 
-This Bolt for JavaScript template demonstrates how to build [Agents & Assistants](https://api.slack.com/docs/apps/ai) in Slack.
+This Bolt for JavaScript template demonstrates how to build [AI Apps](https://docs.slack.dev/ai/) in Slack.
 
 Models from [OpenAI](https://openai.com) are used and can be customized for prompts of all kinds.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "display_information": {
-    "name": "Bolt for JavaScript Assistant"
+    "name": "Bolt for JavaScript Agent"
   },
   "features": {
     "app_home": {
@@ -9,11 +9,11 @@
       "messages_tab_read_only_enabled": false
     },
     "bot_user": {
-      "display_name": "Bolt for JavaScript Assistant",
+      "display_name": "Bolt for JavaScript Agent",
       "always_online": false
     },
     "assistant_view": {
-      "assistant_description": "An Assistant built with Bolt for JavaScript, at your service!",
+      "assistant_description": "An Agent built with Bolt for JavaScript, at your service!",
       "suggested_prompts": []
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "bolt-js-assistant-template",
+  "name": "bolt-js-agent-template",
   "version": "1.0.0",
-  "description": "A template for building Slack app Assistants",
+  "description": "A template for building Slack app Agents",
+  "type": "module",
   "main": "app.js",
   "scripts": {
     "check": "npx tsc --checkJs --noEmit --esModuleInterop --target esnext --module nodenext --moduleResolution nodenext app.js",


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

shortens the display name of the app from assistant to agent to prevent app manifest error during intialization

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
