### PR TITLE
fix: reorder dotenv imports in app.js to load .env file properly

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 import 'dotenv/config';
 import { App, LogLevel } from '@slack/bolt';
-
 import { registerListeners } from './listeners/index.js';
 
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@ import 'dotenv/config';
 import { App, LogLevel } from '@slack/bolt';
 import { registerListeners } from './listeners/index.js';
 
-
 // Initialize the Bolt app
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,

--- a/app.js
+++ b/app.js
@@ -1,9 +1,8 @@
+import 'dotenv/config';
 import { App, LogLevel } from '@slack/bolt';
-import { config } from 'dotenv';
+
 import { registerListeners } from './listeners/index.js';
 
-// Load environment variables
-config();
 
 // Initialize the Bolt app
 const app = new App({


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

Moved the environment variable loading to the top of the entry file using `import 'dotenv/config';` to ensure .env variables are available before any other imports execute.

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
