### PR TITLE
chore: pin @types/node to v24 and block @25/@26 in @dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     labels:
       - "npm"
       - "dependencies"
+    ignore:
+      - dependency-name: "@types/node"
+        versions:
+          - "25.x"
+          - "26.x"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
         "@slack/cli-hooks": "^1.3.2",
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.13.2",
         "typescript": "^6.0.3"
       }
     },
@@ -382,12 +382,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1649,9 +1649,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
     "@slack/cli-hooks": "^1.3.2",
-    "@types/node": "^25.6.0",
+    "@types/node": "^24.13.2",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
### Summary

This pull request brings `@types/node` back down to the Node 24 target in bolt-js-assistant-template and guards it against creeping back up.

- Rolls `@types/node` back from `^25.9.1` to `^24.13.2` in `package.json` (lockfile regenerated to `24.13.2`).
- Adds a `25.x`/`26.x` `@types/node` ignore rule to the npm group in `.github/dependabot.yml` so Dependabot won't re-bump it past Node 24.
- Merged latest `main`, so the other recent dependency bumps (Bolt, openai, dotenv, biome) are preserved.

### Testing

- Confirm `@types/node` resolves to `24.13.2` after `npm install`.
- Confirm Dependabot no longer proposes `@types/node` v25/v26 bumps.
